### PR TITLE
Add mask application for color change node

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # Test
+
+## ColorChangeNode
+
+`ColorChangeNode` recolors pixels in an input image wherever the provided mask is non-zero.
+
+### Parameters
+
+- `image` (`IMAGE`): Input image tensor.
+- `mask` (`MASK`): Mask tensor. Pixels with values other than zero will be recolored.
+- `red`, `green`, `blue` (`FLOAT`): Components of the color to apply.
+
+### Example
+
+```python
+from comfy_nodes.color_change_node import ColorChangeNode
+import numpy as np
+
+node = ColorChangeNode()
+image = np.zeros((2, 2, 3), dtype=np.float32)
+mask = np.array([[1, 0], [0, 0]], dtype=np.float32)
+colored, = node.run(image, mask, red=1.0, green=0.0, blue=0.0)
+```

--- a/comfy_nodes/color_change_node.py
+++ b/comfy_nodes/color_change_node.py
@@ -25,7 +25,8 @@ class ColorChangeNode:
         result = image.copy()
         if mask.ndim == 2:
             mask = mask[..., None]
-        result[mask > 0.5] = color
+        mask_bool = mask != 0
+        result[mask_bool] = color
         return (result,)
 
 

--- a/tests/test_color_change_node.py
+++ b/tests/test_color_change_node.py
@@ -1,0 +1,18 @@
+import numpy as np
+from comfy_nodes.color_change_node import ColorChangeNode
+
+def test_apply_color_only_in_mask():
+    node = ColorChangeNode()
+    image = np.zeros((2, 2, 3), dtype=np.float32)
+    mask = np.array([[1, 0], [0, 0]], dtype=np.float32)
+    result, = node.run(image, mask, red=0.2, green=0.4, blue=0.6)
+    expected = np.zeros_like(image)
+    expected[0, 0] = [0.2, 0.4, 0.6]
+    assert np.allclose(result, expected)
+
+def test_mask_dimension_handling():
+    node = ColorChangeNode()
+    image = np.zeros((1, 1, 3), dtype=np.float32)
+    mask = np.array([[[1.0]]], dtype=np.float32)
+    result, = node.run(image, mask, red=0.3, green=0.3, blue=0.3)
+    assert np.allclose(result[0, 0], [0.3, 0.3, 0.3])


### PR DESCRIPTION
## Summary
- extend README with usage docs
- update color change node to only modify non-zero mask regions
- add unit tests for new mask behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68883ec7af94832c9d3b9dd1a8dc4055