### PR TITLE
Add palette mask recoloring and fix docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # Test
+
+## ColorChangeNode
+
+`ColorChangeNode` recolors pixels in an input image wherever the provided mask is non-zero using a color selected from a small palette.
+
+### Parameters
+
+- `image` (`IMAGE`): Input image tensor.
+- `mask` (`MASK`): Mask tensor. Pixels with values other than zero will be recolored.
+- `color` (`STRING`): Name of the color to apply. One of `red`, `green`, `blue`, `yellow`, `cyan`, `magenta`, `white`, or `black`.
+
+### Example
+
+```python
+from comfy_nodes.color_change_node import ColorChangeNode
+import numpy as np
+
+node = ColorChangeNode()
+image = np.zeros((2, 2, 3), dtype=np.float32)
+mask = np.array([[1, 0], [0, 0]], dtype=np.float32)
+colored, = node.run(image, mask, color="green")
+```

--- a/tests/test_color_change_node.py
+++ b/tests/test_color_change_node.py
@@ -1,0 +1,24 @@
+import numpy as np
+import pytest
+from comfy_nodes.color_change_node import ColorChangeNode
+
+
+def test_apply_color_only_in_mask_numpy():
+    node = ColorChangeNode()
+    image = np.zeros((2, 2, 3), dtype=np.float32)
+    mask = np.array([[1, 0], [0, 0]], dtype=np.float32)
+    result, = node.run(image, mask, color="blue")
+    expected = np.zeros_like(image)
+    expected[0, 0] = [0.0, 0.0, 1.0]
+    assert np.allclose(result, expected)
+
+
+def test_apply_color_only_in_mask_torch():
+    torch = pytest.importorskip("torch")
+    node = ColorChangeNode()
+    image = torch.zeros(2, 2, 3)
+    mask = torch.tensor([[0, 1], [0, 0]], dtype=image.dtype)
+    result, = node.run(image, mask, color="green")
+    expected = image.clone()
+    expected[0, 1] = torch.tensor([0.0, 1.0, 0.0])
+    assert torch.allclose(result, expected)


### PR DESCRIPTION
## Summary
- merge updates from `main`
- update `ColorChangeNode` to accept a mask and apply palette colors only to masked pixels
- document masked palette usage in README
- test mask-based coloring for NumPy and optional PyTorch images

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68883ec7af94832c9d3b9dd1a8dc4055