### PR TITLE
Add RGB adjustment node

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,26 @@ image = np.zeros((2, 2, 3), dtype=np.float32)
 mask = np.array([[1, 0], [0, 0]], dtype=np.float32)
 colored, = node.run(image, mask, red=1.0, green=0.0, blue=0.0)
 ```
+
+## RGBAdjustContrastFeatherNode
+
+`RGBAdjustContrastFeatherNode` scales each color channel of the input image,
+adjusts overall contrast, and optionally applies a feathering blur.
+
+### Parameters
+
+- `image` (`IMAGE`): Input image tensor.
+- `red`, `green`, `blue` (`FLOAT`): Multipliers for the color channels.
+- `contrast` (`FLOAT`): Contrast factor, where `1.0` means no change.
+- `feather` (`INT`): Radius of the box blur used for feathering.
+
+### Example
+
+```python
+from comfy_nodes.rgb_adjust_node import RGBAdjustContrastFeatherNode
+import numpy as np
+
+node = RGBAdjustContrastFeatherNode()
+image = np.zeros((2, 2, 3), dtype=np.float32)
+modified, = node.run(image, red=1.5, green=1.0, blue=1.0, contrast=1.2, feather=1)
+```

--- a/comfy_nodes/rgb_adjust_node.py
+++ b/comfy_nodes/rgb_adjust_node.py
@@ -1,0 +1,46 @@
+import numpy as np
+
+class RGBAdjustContrastFeatherNode:
+    """ComfyUI node to adjust color, contrast, and apply feathering."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "image": ("IMAGE",),
+                "red": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 2.0, "step": 0.01}),
+                "green": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 2.0, "step": 0.01}),
+                "blue": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 2.0, "step": 0.01}),
+                "contrast": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 3.0, "step": 0.01}),
+                "feather": ("INT", {"default": 0, "min": 0, "max": 10}),
+            }
+        }
+
+    RETURN_TYPES = ("IMAGE",)
+    FUNCTION = "run"
+    CATEGORY = "Color"
+
+    def _box_blur(self, image, radius):
+        if radius <= 0:
+            return image
+        k = 2 * radius + 1
+        pad = radius
+        padded = np.pad(image, ((pad, pad), (pad, pad), (0, 0)), mode="edge")
+        out = np.zeros_like(image)
+        for i in range(image.shape[0]):
+            for j in range(image.shape[1]):
+                region = padded[i:i + k, j:j + k]
+                out[i, j] = region.mean(axis=(0, 1))
+        return out
+
+    def run(self, image, red=1.0, green=1.0, blue=1.0, contrast=1.0, feather=0):
+        color = np.array([red, green, blue], dtype=image.dtype)
+        result = image * color
+        result = (result - 0.5) * contrast + 0.5
+        result = np.clip(result, 0.0, 1.0)
+        result = self._box_blur(result, int(feather))
+        return (result,)
+
+
+NODE_CLASS_MAPPINGS = {"RGBAdjustContrastFeatherNode": RGBAdjustContrastFeatherNode}
+NODE_DISPLAY_NAME_MAPPINGS = {"RGBAdjustContrastFeatherNode": "RGB Adjust Contrast Feather Node"}

--- a/tests/test_rgb_adjust_node.py
+++ b/tests/test_rgb_adjust_node.py
@@ -1,0 +1,17 @@
+import numpy as np
+from comfy_nodes.rgb_adjust_node import RGBAdjustContrastFeatherNode
+
+def test_color_and_contrast():
+    node = RGBAdjustContrastFeatherNode()
+    image = np.ones((1, 1, 3), dtype=np.float32) * 0.5
+    result, = node.run(image, red=2.0, green=0.5, blue=1.0, contrast=1.0, feather=0)
+    expected = np.array([[[1.0, 0.25, 0.5]]], dtype=np.float32)
+    assert np.allclose(result, expected)
+
+def test_feather_blur():
+    node = RGBAdjustContrastFeatherNode()
+    image = np.zeros((3, 3, 3), dtype=np.float32)
+    image[1,1] = [1.0, 1.0, 1.0]
+    result, = node.run(image, feather=1)
+    center = result[1,1,0]
+    assert center < 1.0 and center > 0.0


### PR DESCRIPTION
## Summary
- implement `RGBAdjustContrastFeatherNode` to modify image colors
- document the new node in README
- add tests for color/contrast adjustments and feathering

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6888708266e8832c9bd3232ee1b80c5b